### PR TITLE
Added ascii encoding for trial_run output

### DIFF
--- a/shreddit.py
+++ b/shreddit.py
@@ -152,6 +152,8 @@ def remove_things(things):
 
         if trial_run:  # Don't do anything, trial mode!
             if verbose:
+                content = thing
+                content = str(content).encode('ascii', 'ignore')
                 print("Would have deleted {thing}: '{content}'".format(
                     thing=thing.id, content=thing))
             continue


### PR DESCRIPTION
It looks like the print statement couldn't output non-ASCII characters (ñ in my case) so I simply set to ignore such characters. 

However, there is a possibility that one of the requirements didn't install properly in my virtualenv and this is not actually necessary. 