### PR TITLE
Use INFO when logging during trail_run

### DIFF
--- a/shreddit.py
+++ b/shreddit.py
@@ -155,7 +155,7 @@ def remove_things(things):
             continue
 
         if trial_run:  # Don't do anything, trial mode!
-            log.debug("Would have deleted {thing}: '{content}'".format(
+            log.info("Would have deleted {thing}: '{content}'".format(
                 thing=thing.id, content=thing))
             continue
 


### PR DESCRIPTION
I was confused when first setting up, by default trail_run is set to True, as is verbosity. But nothing is outputted and took a bit to figure out what was going on. Moving this to an INFO instead of a DEBUG makes much more sense.