### PR TITLE
fix loading config when passed on the command line

### DIFF
--- a/shreddit.py
+++ b/shreddit.py
@@ -45,12 +45,13 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-config = None
 if args.config:
-    config.read(args.config)
+    config_file = args.config
 else:
-    with open('shreddit.yml', 'r') as fh:
-        config = yaml.safe_load(fh)
+    config_file = 'shreddit.yml'
+
+with open(config_file, 'r') as fh:
+    config = yaml.safe_load(fh)
 if config is None:
     raise Exception("No config options passed!")
 


### PR DESCRIPTION
Fixes 
```python
Traceback (most recent call last):
  File "shreddit.py", line 50, in <module>
    config.read(args.config)
AttributeError: 'NoneType' object has no attribute 'read'
```
When calling `python shreddit.py --config shreddit.yml`
