### PR TITLE
Dockerfile to run Shreddit as an hourly cron job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:alpine
+
+COPY . /shreddit
+WORKDIR /shreddit
+RUN pip install -r requirements.txt && python setup.py install
+
+VOLUME /config
+WORKDIR /config
+RUN echo "0 * * * * cd /config && /usr/local/bin/shreddit >> /dev/stdout" >> /etc/crontabs/root
+
+CMD ["/usr/sbin/crond", "-l", "2",  "-f"]


### PR DESCRIPTION
I was wondering if you would be interested in having a docker image for this repo. DockerHub provides [automated docker builds](https://docs.docker.com/docker-hub/builds/) if you setup an integration with Github, so once it is setup things should be pretty hands off unless the installation steps change.

If you are not interested in having the dockerfile be part of your project, I can manage the dockerfile in a separate repo. If this happens, would you be interested in adding a `push_event` so that I can have the image rebuild each time you commit?