### PR TITLE
Add option to skip comment content replacement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 arrow==0.9.0
 decorator==4.0.10
 praw==4.2.0
@@ -10,21 +9,3 @@ tornado==4.3
 update-checker==0.15
 wheel==0.24.0
 appdirs==1.4.3
-=======
-appdirs==1.4.3
-arrow==0.10.0
-backports-abc==0.5
-certifi==2017.4.17
-chardet==3.0.4
-idna==2.5
-praw==5.0.0
-prawcore==0.11.0
-python-dateutil==2.6.0
-PyYAML==3.12
-requests==2.18.1
-shreddit==6.0.7
-six==1.10.0
-tornado==4.5.1
-update-checker==0.16
-urllib3==1.21.1
->>>>>>> 772df35c68a6782b2bd733801458023545977166

--- a/shreddit.yml.example
+++ b/shreddit.yml.example
@@ -64,7 +64,9 @@ save_directory: /tmp
 # Defines what you want to edit deleted content with pre-deletion (to ensure
 # it's not saved in their database).
 # Default: Random string. But this can be detected as spam in some cases.
-# options: [random, dot, "user entered string"]
+# options: [random, dot, original, "user entered string"]
+# Use the original option to keep the original content. This skips replacement
+# entirely. **Note: Your comment will still be available in their database**.
 replacement_format: random
 
 # Debug level, how much output you want

--- a/shreddit/shredder.py
+++ b/shreddit/shredder.py
@@ -113,6 +113,10 @@ class Shredder(object):
         self._logger.info("Deleting submission: #{id} {url}".format(id=sub.id, url=sub.url.encode("utf-8")))
 
     def _remove_comment(self, comment):
+        if self._replacement_format == "original":
+            self._logger.debug("Deleting /r/{}/ #{}".format(comment.subreddit, comment.id))
+            return
+
         if self._replacement_format == "random":
             replacement_text = get_sentence()
         elif self._replacement_format == "dot":

--- a/shreddit/shreddit.yml.example
+++ b/shreddit/shreddit.yml.example
@@ -64,7 +64,9 @@ save_directory: /tmp
 # Defines what you want to edit deleted content with pre-deletion (to ensure
 # it's not saved in their database).
 # Default: Random string. But this can be detected as spam in some cases.
-# options: [random, dot, "user entered string"]
+# options: [random, dot, original, "user entered string"]
+# Use the original option to keep the original content. This skips replacement
+# entirely. **Note: Your comment will still be available in their database**.
 replacement_format: random
 
 # Debug level, how much output you want


### PR DESCRIPTION
ref #123

To enable the new option, set `replacement_format == original` in your `shreddit.yml` file. Comment content replacement will be skipped entirely.

This could be implemented as a separate `skip_replacement` option, but I think it also makes sense as a `replacement_format` option.