### PR TITLE
Fix merge markers in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 arrow==0.9.0
 decorator==4.0.10
 praw==4.2.0
@@ -10,14 +9,9 @@ tornado==4.3
 update-checker==0.15
 wheel==0.24.0
 appdirs==1.4.3
-=======
-appdirs==1.4.3
-arrow==0.10.0
-backports-abc==0.5
 certifi==2017.4.17
 chardet==3.0.4
 idna==2.5
-praw==5.0.0
 prawcore==0.11.0
 python-dateutil==2.6.0
 PyYAML==3.12
@@ -27,4 +21,3 @@ six==1.10.0
 tornado==4.5.1
 update-checker==0.16
 urllib3==1.21.1
->>>>>>> 772df35c68a6782b2bd733801458023545977166


### PR DESCRIPTION
The file  requirements.txt contains leftover merge makers, this causes an error when trying to install.