### PR TITLE
Fix rare crash

### DIFF
--- a/shreddit/shredder.py
+++ b/shreddit/shredder.py
@@ -107,8 +107,11 @@ class Shredder(object):
             output = {k: item.__dict__[k] for k in item.__dict__ if not k.startswith("_")}
             output["subreddit"] = output["subreddit"].title
             output["author"] = output["author"].name
-            json.dump(output, fh, indent=2)
-
+            try:
+                json.dump(output, fh, indent=2)
+            except:
+                print("could not save post!")
+                
     def _remove_submission(self, sub):
         self._logger.info("Deleting submission: #{id} {url}".format(id=sub.id, url=sub.url.encode("utf-8")))
 


### PR DESCRIPTION
This change prevent the ``Object of type PollData is not JSON serializable `` error from crashing the scriot when saving posts is enabled.